### PR TITLE
add a way to get the weather data in a usable format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Hide the API Key
+/UnityProjekte/Base Project/Assets/Scripts/APIKey.cs
+/UnityProjekte/Base Project/Assets/Scripts/APIKey.cs.meta

--- a/UnityProjekte/Base Project/Assets/Scripts.meta
+++ b/UnityProjekte/Base Project/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d7fa26b9dcafc41429911681b4616e99
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjekte/Base Project/Assets/Scripts/WeatherGetter.cs
+++ b/UnityProjekte/Base Project/Assets/Scripts/WeatherGetter.cs
@@ -9,14 +9,13 @@ public class WeatherGetter : MonoBehaviour
     //API Key is hidden inside a static class
     private string apiKey = APIKey.apiKey;
     private string baseURL = "https://api.openweathermap.org/data/2.5/weather?appid=";
-   [SerializeField] private float lat = 42.2f;
-   [SerializeField] private float lon = 12.0f;
+   //will be null unless something has been requested
     private string result = null;
     
     // Start is called before the first frame update
     void Start()
     {
-        Coroutine rout =   StartCoroutine(GetRequest(lat,lon));
+        
         
     }
 
@@ -24,22 +23,19 @@ public class WeatherGetter : MonoBehaviour
     void Update()
     {
 
-        if(result != null) {
-        Root res = JsonUtility.FromJson<Root>(result);
-        }
     }
     IEnumerator GetRequest(float lat, float lon)
 {
     //using (UnityWebRequest www = UnityWebRequest.Get(baseURL+"&appid=" + apiKey +"&lat=" + lat + "&lon=" + lon ))
     using (UnityWebRequest www = UnityWebRequest.Get(baseURL + apiKey + "&lat=" + lat + "&lon=" + lon ))
     {
-        Debug.Log(baseURL+"&lat=" + lat + "&lon=" + lon + "&appid=" + apiKey);
+        
         yield return www.SendWebRequest();
 
         if (www.result == UnityWebRequest.Result.Success)
         {
-            Debug.Log("Received: " + www.downloadHandler.text);
             result = www.downloadHandler.text;
+            Root res = JsonUtility.FromJson<Root>(result);
         }
         else
         {
@@ -48,17 +44,22 @@ public class WeatherGetter : MonoBehaviour
     } // The using block ensures www.Dispose() is called when this block is exited
 
 }
-public currentWeather getCurrentWeather(){
+// this will return the current weather if something was requested. Otherwise it will continue return null, unless something arrives
+public currentWeather getWeather(){
         if (result != null) {
             Root res = JsonUtility.FromJson<Root>(result);
-            // Weather wea = JsonUtility.FromJson<Weather>(result);
 
             Weather[] wea = res.weather.ToArray();
 
-            Debug.Log("Current Weather is updated");
             return new currentWeather(res.main.temp, wea[0].id, wea[0].main, wea[0].description, wea[0].icon);
     }
     else return null;
 
+}
+//this start a lookup for the weather at a new location, it invalidates the currently cached weather and makes no guarantee that something new will replace it (eg. the internet may be down)
+public void updateLocation(float lat, float lon){
+    result = null;
+    //start coroutine
+    Coroutine rout = StartCoroutine(GetRequest(lat,lon));
 }
 }

--- a/UnityProjekte/Base Project/Assets/Scripts/WeatherGetter.cs
+++ b/UnityProjekte/Base Project/Assets/Scripts/WeatherGetter.cs
@@ -24,10 +24,30 @@ public class WeatherGetter : MonoBehaviour
     {
 
     }
-    IEnumerator GetRequest(float lat, float lon)
+    IEnumerator GetRequestCordinates(float lat, float lon)
 {
     //using (UnityWebRequest www = UnityWebRequest.Get(baseURL+"&appid=" + apiKey +"&lat=" + lat + "&lon=" + lon ))
     using (UnityWebRequest www = UnityWebRequest.Get(baseURL + apiKey + "&lat=" + lat + "&lon=" + lon ))
+    {
+        
+        yield return www.SendWebRequest();
+
+        if (www.result == UnityWebRequest.Result.Success)
+        {
+            result = www.downloadHandler.text;
+            Root res = JsonUtility.FromJson<Root>(result);
+        }
+        else
+        {
+            Debug.Log("Error: " + www.error);
+        }
+    } // The using block ensures www.Dispose() is called when this block is exited
+
+}
+    IEnumerator GetRequestString(string searchstring)
+{
+    //using (UnityWebRequest www = UnityWebRequest.Get(baseURL+"&appid=" + apiKey +"&lat=" + lat + "&lon=" + lon ))
+    using (UnityWebRequest www = UnityWebRequest.Get(baseURL + apiKey + "&q=" + searchstring))
     {
         
         yield return www.SendWebRequest();
@@ -58,8 +78,17 @@ public currentWeather getWeather(){
 }
 //this start a lookup for the weather at a new location, it invalidates the currently cached weather and makes no guarantee that something new will replace it (eg. the internet may be down)
 public void updateLocation(float lat, float lon){
+    //invalidate existing result, since the requested location has changed
     result = null;
     //start coroutine
-    Coroutine rout = StartCoroutine(GetRequest(lat,lon));
+    Coroutine rout = StartCoroutine(GetRequestCordinates(lat,lon));
+}
+//same as updateLocation, but with a string instead of coordinates, expects sanitized input
+public void updateLocationFromString(string city){
+    //invalidate existing result, since the requested location has changed
+    result = null;
+    //start coroutine
+    Coroutine rout = StartCoroutine(GetRequestString(city));
+
 }
 }

--- a/UnityProjekte/Base Project/Assets/Scripts/WeatherGetter.cs
+++ b/UnityProjekte/Base Project/Assets/Scripts/WeatherGetter.cs
@@ -6,7 +6,8 @@ using UnityEngine;
 
 public class WeatherGetter : MonoBehaviour
 {
-    private string apiKey = "";
+    //API Key is hidden inside a static class
+    private string apiKey = APIKey.apiKey;
     private string baseURL = "https://api.openweathermap.org/data/2.5/weather?appid=";
    [SerializeField] private float lat = 42.2f;
    [SerializeField] private float lon = 12.0f;

--- a/UnityProjekte/Base Project/Assets/Scripts/WeatherGetter.cs
+++ b/UnityProjekte/Base Project/Assets/Scripts/WeatherGetter.cs
@@ -1,0 +1,63 @@
+using System.Collections;
+using UnityEngine.Networking;
+using System.Collections.Generic;
+using UnityEngine;
+//using Unity.VisualScripting;
+
+public class WeatherGetter : MonoBehaviour
+{
+    private string apiKey = "";
+    private string baseURL = "https://api.openweathermap.org/data/2.5/weather?appid=";
+   [SerializeField] private float lat = 42.2f;
+   [SerializeField] private float lon = 12.0f;
+    private string result = null;
+    
+    // Start is called before the first frame update
+    void Start()
+    {
+        Coroutine rout =   StartCoroutine(GetRequest(lat,lon));
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+
+        if(result != null) {
+        Root res = JsonUtility.FromJson<Root>(result);
+        }
+    }
+    IEnumerator GetRequest(float lat, float lon)
+{
+    //using (UnityWebRequest www = UnityWebRequest.Get(baseURL+"&appid=" + apiKey +"&lat=" + lat + "&lon=" + lon ))
+    using (UnityWebRequest www = UnityWebRequest.Get(baseURL + apiKey + "&lat=" + lat + "&lon=" + lon ))
+    {
+        Debug.Log(baseURL+"&lat=" + lat + "&lon=" + lon + "&appid=" + apiKey);
+        yield return www.SendWebRequest();
+
+        if (www.result == UnityWebRequest.Result.Success)
+        {
+            Debug.Log("Received: " + www.downloadHandler.text);
+            result = www.downloadHandler.text;
+        }
+        else
+        {
+            Debug.Log("Error: " + www.error);
+        }
+    } // The using block ensures www.Dispose() is called when this block is exited
+
+}
+public currentWeather getCurrentWeather(){
+        if (result != null) {
+            Root res = JsonUtility.FromJson<Root>(result);
+            // Weather wea = JsonUtility.FromJson<Weather>(result);
+
+            Weather[] wea = res.weather.ToArray();
+
+            Debug.Log("Current Weather is updated");
+            return new currentWeather(res.main.temp, wea[0].id, wea[0].main, wea[0].description, wea[0].icon);
+    }
+    else return null;
+
+}
+}

--- a/UnityProjekte/Base Project/Assets/Scripts/WeatherGetter.cs.meta
+++ b/UnityProjekte/Base Project/Assets/Scripts/WeatherGetter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b60a4bb5ab9d05b459b1c98db6459a81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjekte/Base Project/Assets/Scripts/currentWeather.cs
+++ b/UnityProjekte/Base Project/Assets/Scripts/currentWeather.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 public class currentWeather {
 
     //Default Data
+    //Temperature in °C
     public double temp = 0.0f;
     public int id = 0;
     public WeatherType weatherType;
@@ -14,8 +15,8 @@ public class currentWeather {
     public string icon = "###";
 
     public currentWeather(double temp, int id, string main, string description, string icon) {
-
-        this.temp = temp;
+        //K to °C
+        this.temp = temp - 273.15;
         this.id = id;
         this.main = main;
         this.description = description;
@@ -24,7 +25,7 @@ public class currentWeather {
     }
 
     public enum WeatherType{
-        Sun,Rain,Clouds,Snow
+        SUN,RAIN,SNOW,CLOUDS
     }
     //Based on: https://openweathermap.org/weather-conditions
     public WeatherType parseWeatherFromID(int id){
@@ -36,21 +37,21 @@ public class currentWeather {
             case 3:
             //Rain
             case 5:
-            return WeatherType.Rain;
+            return WeatherType.RAIN;
             break;
             //Snow
             case 6:
-            return WeatherType.Snow;
+            return WeatherType.SNOW;
             break;
             //Atmosphere
             case 7:
             case 8:
-            if(id == 800) return WeatherType.Sun;
-            return WeatherType.Clouds;
+            if(id == 800) return WeatherType.SUN;
+            return WeatherType.CLOUDS;
             break;
             //this should never happen, we just pretend nothing is wrong
             default:
-            return WeatherType.Sun;
+            return WeatherType.SUN;
         }
     }
 

--- a/UnityProjekte/Base Project/Assets/Scripts/currentWeather.cs
+++ b/UnityProjekte/Base Project/Assets/Scripts/currentWeather.cs
@@ -8,7 +8,8 @@ public class currentWeather {
     //Default Data
     public double temp = 0.0f;
     public int id = 0;
-    public string main = "default";
+    public WeatherType weatherType;
+    public string main;
     public string description = "default";
     public string icon = "###";
 
@@ -19,7 +20,38 @@ public class currentWeather {
         this.main = main;
         this.description = description;
         this.icon = icon;
+        weatherType = parseWeatherFromID(id);
+    }
 
+    public enum WeatherType{
+        Sun,Rain,Clouds,Snow
+    }
+    //Based on: https://openweathermap.org/weather-conditions
+    public WeatherType parseWeatherFromID(int id){
+        int firstDigit = id/100;
+        switch (firstDigit){
+            //Thunderstorm
+            case 2:
+            //Drizzle
+            case 3:
+            //Rain
+            case 5:
+            return WeatherType.Rain;
+            break;
+            //Snow
+            case 6:
+            return WeatherType.Snow;
+            break;
+            //Atmosphere
+            case 7:
+            case 8:
+            if(id == 800) return WeatherType.Sun;
+            return WeatherType.Clouds;
+            break;
+            //this should never happen, we just pretend nothing is wrong
+            default:
+            return WeatherType.Sun;
+        }
     }
 
 }

--- a/UnityProjekte/Base Project/Assets/Scripts/currentWeather.cs
+++ b/UnityProjekte/Base Project/Assets/Scripts/currentWeather.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+//using Unity.VisualScripting;
+using UnityEngine;
+
+public class currentWeather {
+
+    //Default Data
+    public double temp = 0.0f;
+    public int id = 0;
+    public string main = "default";
+    public string description = "default";
+    public string icon = "###";
+
+    public currentWeather(double temp, int id, string main, string description, string icon) {
+
+        this.temp = temp;
+        this.id = id;
+        this.main = main;
+        this.description = description;
+        this.icon = icon;
+
+    }
+
+}
+    

--- a/UnityProjekte/Base Project/Assets/Scripts/currentWeather.cs.meta
+++ b/UnityProjekte/Base Project/Assets/Scripts/currentWeather.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a386c1240b02b3d4692015a265aa78f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjekte/Base Project/Assets/Scripts/exampleUIText.cs
+++ b/UnityProjekte/Base Project/Assets/Scripts/exampleUIText.cs
@@ -1,0 +1,55 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using TMPro;
+
+public class exampleUIText : MonoBehaviour
+{
+    public WeatherGetter weatherGetter;
+    //this is where the temperature will be shown, place me wherever
+    public TMP_Text temperatureText;
+    //this is where the temperature will be shown, place me wherever
+    public TMP_Text friendlyNameText;
+    public string exampleCity = "Tübingen";
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        //get the weather from a city
+        weatherGetter.updateLocationFromString(exampleCity);
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        currentWeather weather = weatherGetter.getWeather();
+        if(weather != null){
+            temperatureText.text = weather.temp + " °C";
+            friendlyNameText.text = weatherToFriendlyString(weather.weatherType);
+
+        }
+        else{
+            temperatureText.text = "";
+            friendlyNameText.text = "Laden ...";
+        }
+
+    }
+
+    string weatherToFriendlyString(currentWeather.WeatherType weather){
+        switch(weather){
+            case currentWeather.WeatherType.RAIN:
+            return "Regen";
+            case currentWeather.WeatherType.SUN:
+            return "Sonne";
+            case currentWeather.WeatherType.SNOW:
+            return "Schnee";
+            case currentWeather.WeatherType.CLOUDS:
+            return "Wolken";
+            //in case of new types of weather, add them here, eg. 
+            default:
+            return "Todo: Implement";
+        }
+
+    }
+}

--- a/UnityProjekte/Base Project/Assets/Scripts/exampleUIText.cs.meta
+++ b/UnityProjekte/Base Project/Assets/Scripts/exampleUIText.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88713612d0d26c84cb8cfa786d8af94f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjekte/Base Project/Assets/Scripts/weatherAPIResult.cs
+++ b/UnityProjekte/Base Project/Assets/Scripts/weatherAPIResult.cs
@@ -1,0 +1,73 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+
+// Root myDeserializedClass = JsonConvert.DeserializeObject<Root>(myJsonResponse);
+    public class Clouds
+    {
+        public int all ;
+    }
+[System.Serializable]
+
+    public class Coord
+    {
+        public int lon ;
+        public double lat ;
+    }
+[System.Serializable]
+    public class Main
+    {
+        public double temp;
+        public double feels_like ;
+        public double temp_min ;
+        public double temp_max ;
+        public int pressure ;
+        public int humidity ;
+    }
+[System.Serializable]
+
+    public class Root
+    {
+        public Coord coord ;
+        public List<Weather> weather ;
+        public string @base ;
+        public Main main;
+        public int visibility ;
+        public Wind wind ;
+        public Clouds clouds ;
+        public int dt ;
+        public Sys sys ;
+        public int timezone ;
+        public int id ;
+        public string name ;
+        public int cod ;
+    }
+[System.Serializable]
+
+    public class Sys
+    {
+        public int type ;
+        public int id ;
+        public string country ;
+        public int sunrise ;
+        public int sunset ;
+    }
+[System.Serializable]
+
+    public class Weather
+    {
+        public int id ;
+        public string main ;
+        public string description ;
+        public string icon ;
+    }
+[System.Serializable]
+
+    public class Wind
+    {
+        public double speed ;
+        public int deg ;
+        public double gust ;
+    }
+

--- a/UnityProjekte/Base Project/Assets/Scripts/weatherAPIResult.cs.meta
+++ b/UnityProjekte/Base Project/Assets/Scripts/weatherAPIResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b37525e32c2ec64596c685c9958c5c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjekte/Base Project/Assets/Scripts/weatherConsumer.cs
+++ b/UnityProjekte/Base Project/Assets/Scripts/weatherConsumer.cs
@@ -20,7 +20,7 @@ public class weatherConsumer : MonoBehaviour {
         if (weather == null) Debug.Log("Waiting for request");
         else {
             if(!printed){
-                
+                Debug.Log("Weather from ID:" + weather.weatherType);
                 Debug.Log("Temp:" + weather.temp);
                 Debug.Log(weather.description);
                 printed = true;

--- a/UnityProjekte/Base Project/Assets/Scripts/weatherConsumer.cs
+++ b/UnityProjekte/Base Project/Assets/Scripts/weatherConsumer.cs
@@ -3,21 +3,29 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class weatherConsumer : MonoBehaviour {
+    [SerializeField] private float lat = 42.2f;
+    [SerializeField] private float lon = 12.0f;
     public WeatherGetter weatherGetter;
+    currentWeather weather;
+    bool printed = false;
     // Start is called before the first frame update
     void Start() {
-
+        //set random example location
+        weatherGetter.updateLocation(lat,lon);
     }
 
     // Update is called once per frame
     void Update() {
-        
-        currentWeather weather = weatherGetter.getCurrentWeather();
+        currentWeather weather = weatherGetter.getWeather();
         if (weather == null) Debug.Log("Waiting for request");
         else {
+            if(!printed){
+                
+                Debug.Log("Temp:" + weather.temp);
+                Debug.Log(weather.description);
+                printed = true;
+            }
 
-            Debug.Log(weather.temp);
-            Debug.Log(weather.description);
 
         }
     }

--- a/UnityProjekte/Base Project/Assets/Scripts/weatherConsumer.cs
+++ b/UnityProjekte/Base Project/Assets/Scripts/weatherConsumer.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class weatherConsumer : MonoBehaviour {
+    public WeatherGetter weatherGetter;
+    // Start is called before the first frame update
+    void Start() {
+
+    }
+
+    // Update is called once per frame
+    void Update() {
+        
+        currentWeather weather = weatherGetter.getCurrentWeather();
+        if (weather == null) Debug.Log("Waiting for request");
+        else {
+
+            Debug.Log(weather.temp);
+            Debug.Log(weather.description);
+
+        }
+    }
+
+}
+

--- a/UnityProjekte/Base Project/Assets/Scripts/weatherConsumer.cs.meta
+++ b/UnityProjekte/Base Project/Assets/Scripts/weatherConsumer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f40031af02a4efb4fb6b05a3fb86a687
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjekte/Base Project/Assets/a.unity
+++ b/UnityProjekte/Base Project/Assets/a.unity
@@ -1,0 +1,871 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &545900610
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 545900612}
+  - component: {fileID: 545900611}
+  m_Layer: 0
+  m_Name: weatherGetter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &545900611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 545900610}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b60a4bb5ab9d05b459b1c98db6459a81, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &545900612
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 545900610}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 881563702}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &881563700
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 881563702}
+  - component: {fileID: 881563701}
+  m_Layer: 0
+  m_Name: UIController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &881563701
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 881563700}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 88713612d0d26c84cb8cfa786d8af94f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  weatherGetter: {fileID: 545900611}
+  temperatureText: {fileID: 1968997613}
+  friendlyNameText: {fileID: 1184906012}
+  exampleCity: "T\xFCbingen"
+--- !u!4 &881563702
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 881563700}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 545900612}
+  - {fileID: 1184906014}
+  - {fileID: 1968997615}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1040171017
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1040171019}
+  - component: {fileID: 1040171018}
+  m_Layer: 0
+  m_Name: exampleWeatherConsumer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1040171018
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1040171017}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f40031af02a4efb4fb6b05a3fb86a687, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  lat: 42.2
+  lon: 12
+  weatherGetter: {fileID: 545900611}
+--- !u!4 &1040171019
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1040171017}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1184906011
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1184906014}
+  - component: {fileID: 1184906013}
+  - component: {fileID: 1184906012}
+  m_Layer: 0
+  m_Name: Friendly Name
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1184906012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1184906011}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: friendly name
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: -3.092081, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 1184906013}
+  m_maskType: 0
+--- !u!23 &1184906013
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1184906011}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!224 &1184906014
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1184906011}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 881563702}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1.45, y: 2.18}
+  m_SizeDelta: {x: 20, y: 5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1875093420
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1875093423}
+  - component: {fileID: 1875093422}
+  - component: {fileID: 1875093421}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1875093421
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1875093420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+--- !u!108 &1875093422
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1875093420}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1875093423
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1875093420}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1968997612
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1968997615}
+  - component: {fileID: 1968997614}
+  - component: {fileID: 1968997613}
+  m_Layer: 0
+  m_Name: Temperature
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1968997613
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1968997612}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Temp
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 1968997614}
+  m_maskType: 0
+--- !u!23 &1968997614
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1968997612}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!224 &1968997615
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1968997612}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 881563702}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 1.18, y: -1.32}
+  m_SizeDelta: {x: 20, y: 5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2062350667
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2062350670}
+  - component: {fileID: 2062350669}
+  - component: {fileID: 2062350668}
+  - component: {fileID: 2062350671}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &2062350668
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2062350667}
+  m_Enabled: 1
+--- !u!20 &2062350669
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2062350667}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &2062350670
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2062350667}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2062350671
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2062350667}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 2062350670}
+  - {fileID: 1875093423}
+  - {fileID: 1040171019}
+  - {fileID: 881563702}

--- a/UnityProjekte/Base Project/Assets/a.unity.meta
+++ b/UnityProjekte/Base Project/Assets/a.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0178699c9d800794a8e998686e3ae0f0
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Der PR fügt zwei neue Objekte zum Projekt hinzu: den weatherGetter und den exampleWeatherConsumer. Der weatherGetter bietet zwei Methoden an: getWeather und updateLocation. Zunächst muss mit den gewünschten Koordinaten updateLocation aufgerufen werden. Nach dem Aufruf werden die Wetterdaten geladen. Da die Zeit für einen Get-Request nicht garantiert kürzer als ein Frame ist, liefert getWeather als Resultat so lange null, bis die Wetterdaten angekommen und verarbeitet sind. Die Funktion gibt sonst ein currentWeather Objekt zurück, das alle Datenfelder enthält, die benötigt werden. Ganz besonders: Temperatur und weatherType, ein Enum mit den Wettertypen, die wir im Proof of Concept verwenden möchten. weatherAPIResult ist nicht öffentlich und nur für die API zu gebrauchen. 
Um den API-Key nicht zu veröffentlichen, liegt dieser in einem separaten Objekt, dass in der .gitignore ausgeschlossen ist. 
Ein simpler Consumer ist als Beispiel vorhanden, der das aktuelle Wetter in der Konsole ausgibt.
resolves #15,#14

EDIT:
Es wurde auf Nachfrage noch Suche über String (z.B. "Tübingen") und eine simple BeispielsUI implementiert. Dazu wurde ein UIController mit Skript eingeführt, der zur Zeit als Platzhalter Temperatur und das Wetter als schönen String in einen TextMeshPro schreibt, zur Zeit noch in einer Beispielstadt.
![grafik](https://github.com/cgtuebingen/spatial_xr/assets/42973022/cafff2e3-099e-445a-8d1a-d0788bfbd20f)
![grafik](https://github.com/cgtuebingen/spatial_xr/assets/42973022/f414f3f2-49d7-47d0-9090-e68325189336)
